### PR TITLE
Implement CalculatorPlugin unit conversion

### DIFF
--- a/AICompanion/Plugins/CalculatorPlugin.swift
+++ b/AICompanion/Plugins/CalculatorPlugin.swift
@@ -107,8 +107,88 @@ class CalculatorPlugin: PluginProtocol {
     
     /// Convert a value from one unit to another
     private func convertUnits(parameters: [String: Any]) async throws -> Any {
-        // TODO: Implement unit conversion
-        return ["result": 0.0, "from_unit": "kg", "to_unit": "lb"]
+        guard
+            let value = parameters["value"] as? Double,
+            let fromUnitString = parameters["from_unit"] as? String,
+            let toUnitString = parameters["to_unit"] as? String
+        else {
+            throw PluginError.invalidParameters("value, from_unit and to_unit parameters are required")
+        }
+
+        guard let fromUnit = unit(from: fromUnitString),
+              let toUnit = unit(from: toUnitString) else {
+            throw PluginError.conversionError("Invalid units")
+        }
+
+        let resultValue: Double
+        if let from = fromUnit as? UnitLength, let to = toUnit as? UnitLength {
+            let measurement = Measurement(value: value, unit: from)
+            resultValue = measurement.converted(to: to).value
+        } else if let from = fromUnit as? UnitMass, let to = toUnit as? UnitMass {
+            let measurement = Measurement(value: value, unit: from)
+            resultValue = measurement.converted(to: to).value
+        } else if let from = fromUnit as? UnitTemperature, let to = toUnit as? UnitTemperature {
+            let measurement = Measurement(value: value, unit: from)
+            resultValue = measurement.converted(to: to).value
+        } else if let from = fromUnit as? UnitVolume, let to = toUnit as? UnitVolume {
+            let measurement = Measurement(value: value, unit: from)
+            resultValue = measurement.converted(to: to).value
+        } else {
+            throw PluginError.conversionError("Incompatible unit types")
+        }
+
+        return ["result": resultValue, "from_unit": fromUnitString, "to_unit": toUnitString]
+    }
+
+    /// Convert a string representation of a unit into a `Unit` type
+    private func unit(from string: String) -> Dimension? {
+        switch string.lowercased() {
+        // Length
+        case "m", "meter", "meters":
+            return UnitLength.meters
+        case "km", "kilometer", "kilometers":
+            return UnitLength.kilometers
+        case "cm", "centimeter", "centimeters":
+            return UnitLength.centimeters
+        case "mm", "millimeter", "millimeters":
+            return UnitLength.millimeters
+        case "ft", "foot", "feet":
+            return UnitLength.feet
+        case "yd", "yard", "yards":
+            return UnitLength.yards
+        case "mi", "mile", "miles":
+            return UnitLength.miles
+        case "in", "inch", "inches":
+            return UnitLength.inches
+
+        // Mass
+        case "g", "gram", "grams":
+            return UnitMass.grams
+        case "kg", "kilogram", "kilograms":
+            return UnitMass.kilograms
+        case "lb", "lbs", "pound", "pounds":
+            return UnitMass.pounds
+        case "oz", "ounce", "ounces":
+            return UnitMass.ounces
+
+        // Volume
+        case "l", "liter", "liters":
+            return UnitVolume.liters
+        case "ml", "milliliter", "milliliters":
+            return UnitVolume.milliliters
+        case "gal", "gallon", "gallons":
+            return UnitVolume.gallons
+
+        // Temperature
+        case "c", "celsius", "\u00B0c":
+            return UnitTemperature.celsius
+        case "f", "fahrenheit", "\u00B0f":
+            return UnitTemperature.fahrenheit
+        case "k", "kelvin", "\u00B0k":
+            return UnitTemperature.kelvin
+        default:
+            return nil
+        }
     }
     
     /// Errors that can occur in the calculator plugin

--- a/Tests/CalculatorPluginTests.swift
+++ b/Tests/CalculatorPluginTests.swift
@@ -1,0 +1,62 @@
+//
+//  CalculatorPluginTests.swift
+//  AI CompanionTests
+//
+//  Created: May 20, 2025
+//
+
+import XCTest
+@testable import AI_Companion
+
+class CalculatorPluginTests: XCTestCase {
+
+    private var plugin: CalculatorPlugin!
+    private var convertTool: AITool!
+
+    override func setUp() {
+        super.setUp()
+        plugin = CalculatorPlugin()
+        convertTool = plugin.tools.first { $0.name == "convert_units" }
+    }
+
+    override func tearDown() {
+        plugin = nil
+        convertTool = nil
+        super.tearDown()
+    }
+
+    func testKilogramsToPounds() async throws {
+        guard let execute = convertTool.execute else {
+            XCTFail("execute closure missing")
+            return
+        }
+        let resultAny = try await execute(["value": 1.0, "from_unit": "kg", "to_unit": "lb"])
+        let result = resultAny as? [String: Any]
+        let value = result?["result"] as? Double
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value!, 2.20462, accuracy: 0.001)
+    }
+
+    func testMetersToCentimeters() async throws {
+        guard let execute = convertTool.execute else {
+            XCTFail("execute closure missing")
+            return
+        }
+        let resultAny = try await execute(["value": 2.0, "from_unit": "m", "to_unit": "cm"])
+        let value = (resultAny as? [String: Any])?["result"] as? Double
+        XCTAssertEqual(value, 200.0, accuracy: 0.001)
+    }
+
+    func testInvalidUnitThrows() async {
+        guard let execute = convertTool.execute else {
+            XCTFail("execute closure missing")
+            return
+        }
+        do {
+            _ = try await execute(["value": 1.0, "from_unit": "foo", "to_unit": "bar"])
+            XCTFail("Expected error not thrown")
+        } catch {
+            XCTAssertTrue(error is CalculatorPlugin.PluginError)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement real unit conversion logic in `CalculatorPlugin` using `Measurement` and unit helpers
- add helper to map string values to `Unit` types
- create tests for the calculator plugin covering conversions and invalid units

## Testing
- `swift test --disable-automatic-resolution` *(fails: unable to fetch packages)*