### PR TITLE
Implement persistence for conversations

### DIFF
--- a/Sources/AICompanion/Models/ConversationSummary.swift
+++ b/Sources/AICompanion/Models/ConversationSummary.swift
@@ -41,15 +41,11 @@ struct ConversationSummary: Codable, Identifiable {
 extension Conversation {
     /// Get all summaries for this conversation
     var summaries: [ConversationSummary] {
-        // In a real implementation, this would fetch from storage
-        // For now, return an empty array
-        return []
+        return ConversationManager.shared.summaries[id] ?? []
     }
     
     /// Get the latest summary for this conversation
     var latestSummary: ConversationSummary? {
-        // In a real implementation, this would fetch from storage
-        // For now, return nil
         return summaries.sorted(by: { $0.createdAt > $1.createdAt }).first
     }
     

--- a/Tests/ConversationManagerPersistenceTests.swift
+++ b/Tests/ConversationManagerPersistenceTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AI_Companion
+
+class ConversationManagerPersistenceTests: XCTestCase {
+    func testConversationPersistence() {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let manager = ConversationManager(directory: tempDir)
+        let conversation = manager.createNewConversation(title: "Persisted")
+        manager.addMessage(Message(role: .user, content: "Hello"))
+        manager.addMessage(Message(role: .assistant, content: "Hi"))
+
+        // Recreate manager to simulate app restart
+        let manager2 = ConversationManager(directory: tempDir)
+        XCTAssertEqual(manager2.conversations.count, manager.conversations.count)
+        let reloaded = manager2.conversations.first { $0.id == conversation.id }
+        XCTAssertEqual(reloaded?.messages.count, conversation.messages.count)
+    }
+
+    func testSummaryPersistence() {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let manager = ConversationManager(directory: tempDir)
+        let conversation = manager.currentConversation
+        let summary = ConversationSummary(conversationId: conversation.id, content: "Summary", summarizedMessageIds: [])
+        manager.saveSummary(summary)
+
+        let manager2 = ConversationManager(directory: tempDir)
+        let loadedSummaries = manager2.summaries[conversation.id] ?? []
+        XCTAssertEqual(loadedSummaries.count, 1)
+        XCTAssertEqual(loadedSummaries.first?.content, "Summary")
+    }
+}


### PR DESCRIPTION
## Summary
- add JSON-based persistence to `ConversationManager`
- expose saved summaries through `Conversation` model extension
- add tests for saving/loading conversations and summaries

## Testing
- `swift test` *(fails: package dependencies missing)*