### PR TITLE
Implement update manager networking and tests

### DIFF
--- a/AICompanion/Services/UpdateManager.swift
+++ b/AICompanion/Services/UpdateManager.swift
@@ -8,6 +8,16 @@
 
 import Foundation
 import Combine
+import UserNotifications
+import AppKit
+
+/// Protocol abstraction for URLSession to allow mocking in tests
+protocol URLSessionProtocol {
+    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    func downloadTask(with url: URL, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask
+}
+
+extension URLSession: URLSessionProtocol {}
 
 /// Manager for handling application updates
 class UpdateManager: ObservableObject {
@@ -32,13 +42,20 @@ class UpdateManager: ObservableObject {
     
     /// URL for the update server
     private let updateServerURL = URL(string: "https://aicompanion.example.com/updates")!
+
+    /// URL session used for network calls (injected for testing)
+    private let session: URLSessionProtocol
+
+    /// Download URL for the latest version
+    private var downloadURL: URL?
     
     /// Cancellables for managing subscriptions
     private var cancellables = Set<AnyCancellable>()
     
-    init() {
+    init(currentVersion: String? = nil, session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
         // Get current version from bundle
-        currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        self.currentVersion = currentVersion ?? Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
         
         // Load user preferences
         checkAutomatically = UserDefaults.standard.bool(forKey: "checkForUpdatesAutomatically")
@@ -53,14 +70,86 @@ class UpdateManager: ObservableObject {
     private func saveCheckAutomatically() {
         UserDefaults.standard.set(checkAutomatically, forKey: "checkForUpdatesAutomatically")
     }
-    
+
     /// Check for updates
     func checkForUpdates() {
-        // TODO: Implement update checking
+        let task = session.dataTask(with: updateServerURL) { [weak self] data, response, error in
+            guard let self = self else { return }
+
+            guard error == nil,
+                  let data = data,
+                  let response = response as? HTTPURLResponse,
+                  response.statusCode == 200 else {
+                return
+            }
+
+            struct UpdateInfo: Decodable {
+                let version: String
+                let downloadURL: URL
+            }
+
+            guard let info = try? JSONDecoder().decode(UpdateInfo.self, from: data) else { return }
+
+            let isNewer = self.isNewerVersion(info.version, than: self.currentVersion)
+
+            DispatchQueue.main.async {
+                self.latestVersion = info.version
+                self.updateAvailable = isNewer
+                self.downloadURL = info.downloadURL
+
+                if isNewer {
+                    self.notifyUserAboutUpdate(version: info.version)
+                }
+            }
+        }
+
+        task.resume()
     }
-    
+
     /// Download and install the update
     func downloadAndInstallUpdate() {
-        // TODO: Implement update installation
+        guard let downloadURL else { return }
+
+        let task = session.downloadTask(with: downloadURL) { url, response, error in
+            guard let tempURL = url, error == nil else { return }
+
+            // Move downloaded file to a permanent location
+            let destination = FileManager.default.temporaryDirectory.appendingPathComponent(downloadURL.lastPathComponent)
+            try? FileManager.default.removeItem(at: destination)
+            do {
+                try FileManager.default.moveItem(at: tempURL, to: destination)
+                DispatchQueue.main.async {
+                    NSWorkspace.shared.open(destination)
+                }
+            } catch {
+                // Handle move error silently
+            }
+        }
+
+        task.resume()
+    }
+
+    /// Compare semantic versions (e.g., 1.2.3)
+    private func isNewerVersion(_ new: String, than current: String) -> Bool {
+        let newParts = new.split(separator: ".").compactMap { Int($0) }
+        let currentParts = current.split(separator: ".").compactMap { Int($0) }
+        for (new, old) in zip(newParts, currentParts) {
+            if new > old { return true }
+            if new < old { return false }
+        }
+        return newParts.count > currentParts.count && newParts.dropFirst(currentParts.count).contains { $0 > 0 }
+    }
+
+    /// Notify the user that an update is available
+    private func notifyUserAboutUpdate(version: String) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Update Available"
+            content.body = "Version \(version) is available to download."
+            let request = UNNotificationRequest(identifier: "AICompanionUpdate", content: content, trigger: nil)
+            center.add(request, withCompletionHandler: nil)
+        }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,8 @@ let package = Package(
                     "-framework", "ARKit",
                     "-framework", "RealityKit",
                     "-framework", "CoreLocation",
-                    "-framework", "Combine"
+                    "-framework", "Combine",
+                    "-framework", "UserNotifications"
                 ])
             ]),
         .testTarget(
@@ -64,6 +65,7 @@ let package = Package(
                     "-framework", "RealityKit",
                     "-framework", "CoreLocation",
                     "-framework", "Combine",
+                    "-framework", "UserNotifications",
                     "-framework", "XCTest"
                 ])
             ]),

--- a/Tests/UpdateManagerTests.swift
+++ b/Tests/UpdateManagerTests.swift
@@ -1,0 +1,83 @@
+//
+//  UpdateManagerTests.swift
+//  AI CompanionTests
+//
+//  Created: May 21, 2025
+//
+
+import XCTest
+@testable import AI_Companion
+
+private class MockDataTask: URLSessionDataTask {
+    let onResume: () -> Void
+    init(onResume: @escaping () -> Void) { self.onResume = onResume }
+    override func resume() { onResume() }
+}
+
+private class MockDownloadTask: URLSessionDownloadTask {
+    let onResume: () -> Void
+    init(onResume: @escaping () -> Void) { self.onResume = onResume }
+    override func resume() { onResume() }
+}
+
+private class MockURLSession: URLSessionProtocol {
+    var data: Data?
+    var downloadFileURL: URL?
+
+    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        return MockDataTask {
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            completionHandler(self.data, response, nil)
+        }
+    }
+
+    func downloadTask(with url: URL, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
+        return MockDownloadTask {
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            completionHandler(self.downloadFileURL, response, nil)
+        }
+    }
+}
+
+class UpdateManagerTests: XCTestCase {
+    func testCheckForUpdatesWithNewVersion() {
+        let mockSession = MockURLSession()
+        let json = "{" + "\"version\":\"2.0.0\"," + "\"downloadURL\":\"https://example.com/app.dmg\"}"
+        mockSession.data = json.data(using: .utf8)
+
+        let manager = UpdateManager(currentVersion: "1.0.0", session: mockSession)
+        manager.checkForUpdates()
+
+        XCTAssertTrue(manager.updateAvailable)
+        XCTAssertEqual(manager.latestVersion, "2.0.0")
+    }
+
+    func testCheckForUpdatesWhenUpToDate() {
+        let mockSession = MockURLSession()
+        let json = "{" + "\"version\":\"1.0.0\"," + "\"downloadURL\":\"https://example.com/app.dmg\"}"
+        mockSession.data = json.data(using: .utf8)
+
+        let manager = UpdateManager(currentVersion: "1.0.0", session: mockSession)
+        manager.checkForUpdates()
+
+        XCTAssertFalse(manager.updateAvailable)
+    }
+
+    func testDownloadAndInstallUpdateMovesFile() {
+        let mockSession = MockURLSession()
+        let json = "{" + "\"version\":\"2.0.0\"," + "\"downloadURL\":\"https://example.com/app.dmg\"}"
+        mockSession.data = json.data(using: .utf8)
+
+        let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("test.dmg")
+        FileManager.default.createFile(atPath: tempFile.path, contents: Data("123".utf8), attributes: nil)
+        mockSession.downloadFileURL = tempFile
+
+        let manager = UpdateManager(currentVersion: "1.0.0", session: mockSession)
+        manager.checkForUpdates()
+        manager.downloadAndInstallUpdate()
+
+        let destination = FileManager.default.temporaryDirectory.appendingPathComponent("app.dmg")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+        try? FileManager.default.removeItem(at: destination)
+    }
+}


### PR DESCRIPTION
## Summary
- add URLSession abstraction and real network logic to `UpdateManager`
- support user notifications and installation download handling
- expose frameworks for `UserNotifications` in Package.swift
- add tests exercising update flow with mocked sessions

## Testing
- `swift test -q` *(fails: package dependencies can't be fetched)*